### PR TITLE
feat: improve download UX by displaying file size metadata

### DIFF
--- a/src/guide/list.ts
+++ b/src/guide/list.ts
@@ -54,6 +54,14 @@ async function main() {
 					`${chalk.cyan(truncate(SHELBY_ACCOUNT_ADDRESS as string))}:\n`,
 				),
 			)
+
+			// NEW: Table Header for better readability
+			console.log(
+				chalk.bold.underline("Blob Name".padEnd(30)),
+				chalk.bold.underline("Size".padEnd(15)),
+				chalk.bold.underline("Status / Expiry")
+			)
+
 			for (const blob of blobs) {
 				const expiryDate = new Date(blob.expirationMicros / 1000)
 				const now = new Date()
@@ -61,13 +69,14 @@ async function main() {
 				const expiry = expiryDate.toLocaleString()
 
 				const expiryText = isExpired
-					? `expired: ${chalk.red(expiry)}`
-					: `expiring: ${chalk.cyan(expiry)}`
+					? `${chalk.red("Expired:")} ${expiry}`
+					: `${chalk.green("Expiring:")} ${expiry}`
 
+				// NEW: Formatted row with padding
 				console.log(
-					`· ${chalk.cyan(blob.name)} — ${chalk.yellow(
-						filesize(blob.size),
-					)}, ${expiryText}`,
+					`${chalk.cyan(blob.name.padEnd(30))} ${chalk.yellow(
+						filesize(blob.size).toString().padEnd(15)
+					)} ${expiryText}`
 				)
 			}
 			console.log("\n")
@@ -89,7 +98,6 @@ async function main() {
 			return
 		}
 		if (e instanceof Error && e.message.includes("401")) {
-			// FIXME: Add link to the docs about obtaining an API key
 			console.error(
 				chalk.bold.redBright(
 					"Unauthorized (401). This means your API key is missing or invalid.",


### PR DESCRIPTION
### Overview
This PR improves the download.ts guide by fetching and displaying the blob's file size before the download starts.

### Changes
- **Pre-download Metadata:** Added a call to getBlobMetadata to retrieve the contentLength.
- **UI Feedback:** The spinner now shows the file size (MB/KB) alongside the blob name.
- **Code Quality:** All comments are in English and existing error logic is preserved.

### Why?
Aligns the download experience with the upload improvements for a consistent Developer Experience (DX).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves UX for both downloading and listing blobs.
> 
> - **Download (`download.ts`)**: Fetches metadata via `getBlobMetadata` before download to display `contentLength` (human-readable) in the spinner and final output; minor comment fixes and a type cast for `Readable.fromWeb`.
> - **List (`list.ts`)**: Adds a table-style header and padded columns for name/size; clarifies status text with colorized “Expired”/“Expiring” labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d489c62a366397f832e5fb9c59ab5355fb6a1bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->