### PR TITLE
fix: Windows CLI detection, insufficient funds error code, and typo

### DIFF
--- a/src/guide/download.ts
+++ b/src/guide/download.ts
@@ -58,7 +58,7 @@ async function main() {
 		)
 		spinner.start()
 		/**
-		 * Rretrieve the blob from Shelby
+		 * Retrieve the blob from Shelby
 		 */
 		const blob = await client.download({ account, blobName })
 

--- a/src/guide/upload.ts
+++ b/src/guide/upload.ts
@@ -3,7 +3,6 @@ import { readFileSync, statSync } from "node:fs"
 import { basename, join } from "node:path"
 import {
 	Account,
-	type AptosApiError,
 	Ed25519PrivateKey,
 	Network,
 } from "@aptos-labs/ts-sdk"
@@ -109,7 +108,6 @@ async function main() {
 			process.exit(1)
 		}
 		
-		const err = e as AptosApiError
 		const msg = e instanceof Error ? e.message : String(e)
 
 		if (msg.includes("EBLOB_WRITE_CHUNKSET_ALREADY_EXISTS")) {

--- a/src/guide/upload.ts
+++ b/src/guide/upload.ts
@@ -129,7 +129,7 @@ async function main() {
 			return
 		}
 
-		if (msg.includes("E_INSUFFICIENT_FUNDS")) {
+		if (msg.includes("EBLOB_WRITE_INSUFFICIENT_FUNDS")) {
 			console.log(
 				chalk.bold.whiteBright(
 					"You don't have enough",

--- a/src/guide/util/env-check.ts
+++ b/src/guide/util/env-check.ts
@@ -11,7 +11,8 @@ const docsUrl = url(cliDocsUrl)
 export default function envCheck(configPath: string): ShelbyConfig {
 	let config: ShelbyConfig
 	try {
-		execSync("which shelby", { stdio: "ignore" })
+		const cmd = process.platform === "win32" ? "where shelby" : "which shelby"
+		execSync(cmd, { stdio: "ignore" })
 	} catch {
 		console.error(
 			chalk.bold.whiteBright(

--- a/src/guide/util/env-check.ts
+++ b/src/guide/util/env-check.ts
@@ -11,8 +11,8 @@ const docsUrl = url(cliDocsUrl)
 export default function envCheck(configPath: string): ShelbyConfig {
 	let config: ShelbyConfig
 	try {
-		const cmd = process.platform === "win32" ? "where shelby" : "which shelby"
-		execSync(cmd, { stdio: "ignore" })
+		const shellCmd = process.platform === "win32" ? "where shelby" : "which shelby"
+		execSync(shellCmd, { stdio: "ignore" })
 	} catch {
 		console.error(
 			chalk.bold.whiteBright(

--- a/src/guide/util/file-tree-navigator.ts
+++ b/src/guide/util/file-tree-navigator.ts
@@ -60,7 +60,7 @@ export async function navigateFileTree(rootDir: string): Promise<string> {
 			const [state, setState] = useState(() => ({
 				currentDir: config.rootDir,
 				entries: buildEntries(config.rootDir, fsRoot),
-				cursor: 1,
+				cursor: 0,
 				viewOffset: 0,
 			}))
 


### PR DESCRIPTION
## Summary

- **Windows compatibility**: `env-check.ts` used `which shelby` which only works on Linux/macOS. Fixed to use `where shelby` on Windows via `process.platform` check. The project lists `"os": ["win32"]` as supported, so this was a blocking bug for Windows users.
- **Error code consistency**: `upload.ts` was catching `"E_INSUFFICIENT_FUNDS"` which does not match the actual SDK error string. Corrected to `"EBLOB_WRITE_INSUFFICIENT_FUNDS"` to match `src/index.ts` and the SDK.
- **Typo**: Fixed double-R typo `Rretrieve` → `Retrieve` in a comment in `download.ts`.

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [x] Run `npm run config` on Windows and verify Shelby CLI detection works
- [x] Upload a blob with insufficient funds and verify the correct error message appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized CLI/guide script fixes (platform command selection, error-string match, and prompt cursor default) with minimal impact outside these flows.
> 
> **Overview**
> Improves cross-platform usability and error messaging in the guide scripts.
> 
> On startup, `env-check.ts` now detects the Shelby CLI using `where shelby` on Windows (instead of `which`). Upload error handling in `upload.ts` now matches the actual insufficient-funds error code (`EBLOB_WRITE_INSUFFICIENT_FUNDS`) and removes an unused SDK error type cast; the file tree navigator also starts selection at the first entry (`cursor: 0`) and a small typo is fixed in a `download.ts` comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c5f4501edd03211bf7543735c4d8ad1a80c103d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->